### PR TITLE
Add GitHub Workflows

### DIFF
--- a/.github/workflows/combined.yaml
+++ b/.github/workflows/combined.yaml
@@ -1,0 +1,30 @@
+name: "Validation And Formatting"
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        name: Download repo
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        name: Setup Python
+      - uses: actions/cache@v2
+        name: Cache
+        with:
+          path: |
+            ~/.cache/pip
+          key: custom-component-ci
+      - uses: hacs/integration/action@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CATEGORY: integration
+      - uses: KTibow/ha-blueprint@stable
+        name: CI
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I recently announced ha-blueprint:
- With formatting (black + isort for python, prettier for js)
  - It’ll go ahead and pull it, format it, and amend the changes to the last commit.
- With lint
  - JS: Run ESLint to catch syntax errors
  - Python: It runs Hassfest (to catch invalid integrations), HACS (to catch invalid HACS integrations), and flake8 (to catch invalid python).

https://community.home-assistant.io/t/made-a-custom-integration-or-card-ive-created-an-all-in-one-github-action-for-you/235041
This makes it so it auto-checks for HACS, hassfest, and flake8 so you won't have to worry about it being invalid.