### PR TITLE
Change route type default to int

### DIFF
--- a/custom_components/public_transport_victoria/config_flow.py
+++ b/custom_components/public_transport_victoria/config_flow.py
@@ -57,7 +57,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_route_types(self, user_input=None):
         """Handle the route types step."""
         data_schema = vol.Schema({
-            vol.Required(CONF_ROUTE_TYPE, default="0"): vol.In(self.route_types),
+            vol.Required(CONF_ROUTE_TYPE, default=0): vol.In(self.route_types),
         })
 
         errors = {}


### PR DESCRIPTION
I found that I only needed to change the default to an integer to get it to work. Beforehand, leaving the route type at the default of Train produced an error. Now it proceeds to the next screen as expected. I also tested picking a different type (Tram); and selecting a different type, but reverting to Train before hitting Submit.