### PR TITLE
Add express train detection using run information from PTV API

### DIFF
--- a/custom_components/public_transport_victoria/PublicTransportVictoria/public_transport_victoria.py
+++ b/custom_components/public_transport_victoria/PublicTransportVictoria/public_transport_victoria.py
@@ -140,10 +140,32 @@ class Connector:
                     r["departure"] = convert_utc_to_local(
                         r["scheduled_departure_utc"], self.hass
                         )
+
+                # Get run information to determine if it's express
+                run_info = await self.async_run(r["run_id"])
+                if run_info:
+                    r["is_express"] = run_info.get("express_stop_count", 0) > 0
+                else:
+                    r["is_express"] = None
+
                 self.departures.append(r)
 
         for departure in self.departures:
             _LOGGER.debug(departure)
+
+    async def async_run(self, run_id):
+        """Get run information from Public Transport Victoria API."""
+        url = build_URL(self.id, self.api_key, f"/v3/runs/{run_id}")
+
+        async with aiohttp.ClientSession() as session:
+            response = await session.get(url)
+
+        if response is not None and response.status == 200:
+            response = await response.json()
+            _LOGGER.debug(response)
+            if response.get("runs") and len(response["runs"]) > 0:
+                return response["runs"][0]
+        return None
 
 def build_URL(id, api_key, request):
     request = request + ('&' if ('?' in request) else '?')


### PR DESCRIPTION
I have added and tested an additional attribute called is_express. This reads the express_stop_count from the associated run object. If the stop count is greater than 0, it sets it as an express service.

This relates to a comment for an enhancement I made in https://github.com/bremor/public_transport_victoria/issues/27
